### PR TITLE
Prompt for OAuth credentials on first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Gartner analysts, or direct reports.
    - Create an OAuth client ID for a Web application. Add
      `http://localhost:8080` as an authorized JavaScript origin.
    - Create an API key.
-3. Edit `app.js` and replace `YOUR_CLIENT_ID` and `YOUR_API_KEY` with your own
-   credentials.
+3. When you first launch the app you will be prompted in the browser to enter
+   your OAuth client ID and API key. The app stores these in `localStorage` so
+   you only need to provide them once.
 4. Optionally edit `config.json` to specify emails for key groups:
 
 ```json

--- a/app.js
+++ b/app.js
@@ -1,8 +1,34 @@
-const CLIENT_ID = 'YOUR_CLIENT_ID.apps.googleusercontent.com';
-const API_KEY = 'YOUR_API_KEY';
+function promptForCredentials() {
+  alert(
+    'Ensure you have configured the OAuth consent screen and enabled the Calendar API in the Google Cloud Console.'
+  );
+  const clientId = prompt('Enter your OAuth Client ID:');
+  const apiKey = prompt('Enter your API Key:');
+  if (!clientId || !apiKey) {
+    throw new Error('Credentials are required.');
+  }
+  localStorage.setItem('CLIENT_ID', clientId);
+  localStorage.setItem('API_KEY', apiKey);
+  return { clientId, apiKey };
+}
+
+function loadCredentials() {
+  let clientId = localStorage.getItem('CLIENT_ID');
+  let apiKey = localStorage.getItem('API_KEY');
+  if (!clientId || !apiKey) {
+    ({ clientId, apiKey } = promptForCredentials());
+  }
+  return { clientId, apiKey };
+}
 
 document.getElementById('refresh').addEventListener('click', refresh);
 document.getElementById('refresh').disabled = true;
+document.getElementById('config').addEventListener('click', () => {
+  promptForCredentials();
+  location.reload();
+});
+
+const { clientId: CLIENT_ID, apiKey: API_KEY } = loadCredentials();
 
 window.gapiLoaded = function() {
   gapi.load('client:auth2', initClient);

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
 </head>
 <body>
   <h2>Calendar Analytics</h2>
+  <button id="config">Configure Credentials</button>
   <button id="refresh">Refresh Stats</button>
   <pre id="output"></pre>
   <script src="app.js"></script>


### PR DESCRIPTION
## Summary
- Prompt for OAuth client ID and API key on first launch and store them in localStorage
- Add "Configure Credentials" button to allow resetting credentials
- Update setup instructions to describe credential prompt and OAuth consent screen requirements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd295901588329aaf1158d7cb3c39b