### PR TITLE
feat: inline credential config and viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,13 +18,38 @@
     <h1 class="mb-4 text-center">Calendar Analytics</h1>
     <div class="mb-3 text-center">
       <button id="config" class="btn btn-secondary me-2">Configure Credentials</button>
+      <button id="view-creds" class="btn btn-outline-secondary btn-sm me-2 d-none" title="Show Credentials">🔑</button>
       <button id="refresh" class="btn btn-primary">Refresh Stats</button>
     </div>
     <pre id="output" class="bg-white p-3 border rounded"></pre>
   </div>
+  <div class="modal" tabindex="-1" id="credentialsModal">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Credentials</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label for="clientIdInput" class="form-label">Client ID</label>
+            <input type="text" class="form-control" id="clientIdInput">
+          </div>
+          <div class="mb-3">
+            <label for="apiKeyInput" class="form-label">API Key</label>
+            <input type="text" class="form-control" id="apiKeyInput">
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-primary" id="saveCredentials">Save</button>
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script src="app.js"></script>
   <script async defer src="https://apis.google.com/js/api.js" onload="gapiLoaded()"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- replace prompt-based credential entry with in-app modal and storage
- add small icon to display saved credentials in read-only modal
- initialize Google API client only after credentials exist

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd2f5e4d0083239ae8aea1890ea53b