### PR TITLE
Remove API key usage and rely on OAuth client ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ Gartner analysts, or direct reports.
      `https://www.googleapis.com/auth/calendar.readonly` so the app can read
      your calendar events.
    - Create an OAuth client ID for a Web application. Add
-     `http://localhost:8080` as an authorized JavaScript origin.
-   - Create an API key.
+     `http://localhost:8080` as an authorized JavaScript origin. Note the
+     generated client ID (the client secret is not required in this
+     client-side app).
 3. When you first launch the app you will be prompted in the browser to enter
-   your OAuth client ID and API key. The app stores these in `localStorage` so
-   you only need to provide them once.
+   your OAuth client ID. The app stores this in `sessionStorage` so you only
+   need to provide it once per session.
 4. Optionally edit `config.json` to specify emails for key groups:
 
 ```json

--- a/app.js
+++ b/app.js
@@ -1,12 +1,10 @@
-function saveCredentials(clientId, apiKey) {
+function saveCredentials(clientId) {
   sessionStorage.setItem('CLIENT_ID', clientId);
-  sessionStorage.setItem('API_KEY', apiKey);
 }
 
 function getCredentials() {
   return {
-    clientId: sessionStorage.getItem('CLIENT_ID'),
-    apiKey: sessionStorage.getItem('API_KEY')
+    clientId: sessionStorage.getItem('CLIENT_ID')
   };
 }
 
@@ -18,31 +16,28 @@ document.getElementById('refresh').addEventListener('click', refresh);
 document.getElementById('refresh').disabled = true;
 document.getElementById('config').addEventListener('click', () => {
   document.getElementById('clientIdInput').value = CLIENT_ID || '';
-  document.getElementById('apiKeyInput').value = API_KEY || '';
   document.getElementById('clientIdInput').removeAttribute('readonly');
-  document.getElementById('apiKeyInput').removeAttribute('readonly');
   document.getElementById('saveCredentials').classList.remove('d-none');
   credModal.show();
 });
 
 document.getElementById('view-creds').addEventListener('click', () => {
   document.getElementById('clientIdInput').value = CLIENT_ID || '';
-  document.getElementById('apiKeyInput').value = API_KEY || '';
-  document.getElementById('clientIdInput').setAttribute('readonly', true);
-  document.getElementById('apiKeyInput').setAttribute('readonly', true);
+  document
+    .getElementById('clientIdInput')
+    .setAttribute('readonly', true);
   document.getElementById('saveCredentials').classList.add('d-none');
   credModal.show();
 });
 
 document.getElementById('saveCredentials').addEventListener('click', () => {
   const clientId = document.getElementById('clientIdInput').value.trim();
-  const apiKey = document.getElementById('apiKeyInput').value.trim();
-  if (!clientId || !apiKey) {
-    alert('Both Client ID and API Key are required.');
+  if (!clientId) {
+    alert('Client ID is required.');
     return;
   }
-  saveCredentials(clientId, apiKey);
-  ({ clientId: CLIENT_ID, apiKey: API_KEY } = getCredentials());
+  saveCredentials(clientId);
+  ({ clientId: CLIENT_ID } = getCredentials());
   credModal.hide();
   document.getElementById('view-creds').classList.remove('d-none');
   if (gapiInited) {
@@ -50,8 +45,8 @@ document.getElementById('saveCredentials').addEventListener('click', () => {
   }
 });
 
-let { clientId: CLIENT_ID, apiKey: API_KEY } = getCredentials();
-if (CLIENT_ID && API_KEY) {
+let { clientId: CLIENT_ID } = getCredentials();
+if (CLIENT_ID) {
   document.getElementById('view-creds').classList.remove('d-none');
 }
 
@@ -67,7 +62,7 @@ function formatError(err) {
 let gapiInited = false;
 window.gapiLoaded = function() {
   gapiInited = true;
-  if (CLIENT_ID && API_KEY) {
+  if (CLIENT_ID) {
     gapi.load('client:auth2', initClient);
   }
 };
@@ -77,7 +72,6 @@ async function initClient() {
   refreshBtn.disabled = true;
   try {
     await gapi.client.init({
-      apiKey: API_KEY,
       clientId: CLIENT_ID,
       discoveryDocs: [
         'https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest'

--- a/index.html
+++ b/index.html
@@ -35,10 +35,6 @@
             <label for="clientIdInput" class="form-label">Client ID</label>
             <input type="text" class="form-control" id="clientIdInput">
           </div>
-          <div class="mb-3">
-            <label for="apiKeyInput" class="form-label">API Key</label>
-            <input type="text" class="form-control" id="apiKeyInput">
-          </div>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-primary" id="saveCredentials">Save</button>


### PR DESCRIPTION
## Summary
- Remove API key handling in app initialization and credential storage.
- Simplify UI to request only OAuth client ID.
- Update setup docs to reflect OAuth-only authentication.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd30eb85f883299c73d1d89e60bd94