### PR TITLE
Add client secret support for OAuth credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,10 @@ Gartner analysts, or direct reports.
      your calendar events.
    - Create an OAuth client ID for a Web application. Add
      `http://localhost:8080` as an authorized JavaScript origin. Note the
-     generated client ID (the client secret is not required in this
-     client-side app).
+     generated client ID and client secret.
 3. When you first launch the app you will be prompted in the browser to enter
-   your OAuth client ID. The app stores this in `sessionStorage` so you only
-   need to provide it once per session.
+   your OAuth client ID and client secret. The app stores these in
+   `sessionStorage` so you only need to provide them once per session.
 4. Optionally edit `config.json` to specify emails for key groups:
 
 ```json

--- a/app.js
+++ b/app.js
@@ -1,10 +1,12 @@
-function saveCredentials(clientId) {
+function saveCredentials(clientId, clientSecret) {
   sessionStorage.setItem('CLIENT_ID', clientId);
+  sessionStorage.setItem('CLIENT_SECRET', clientSecret);
 }
 
 function getCredentials() {
   return {
-    clientId: sessionStorage.getItem('CLIENT_ID')
+    clientId: sessionStorage.getItem('CLIENT_ID'),
+    clientSecret: sessionStorage.getItem('CLIENT_SECRET')
   };
 }
 
@@ -16,15 +18,21 @@ document.getElementById('refresh').addEventListener('click', refresh);
 document.getElementById('refresh').disabled = true;
 document.getElementById('config').addEventListener('click', () => {
   document.getElementById('clientIdInput').value = CLIENT_ID || '';
+  document.getElementById('clientSecretInput').value = CLIENT_SECRET || '';
   document.getElementById('clientIdInput').removeAttribute('readonly');
+  document.getElementById('clientSecretInput').removeAttribute('readonly');
   document.getElementById('saveCredentials').classList.remove('d-none');
   credModal.show();
 });
 
 document.getElementById('view-creds').addEventListener('click', () => {
   document.getElementById('clientIdInput').value = CLIENT_ID || '';
+  document.getElementById('clientSecretInput').value = CLIENT_SECRET || '';
   document
     .getElementById('clientIdInput')
+    .setAttribute('readonly', true);
+  document
+    .getElementById('clientSecretInput')
     .setAttribute('readonly', true);
   document.getElementById('saveCredentials').classList.add('d-none');
   credModal.show();
@@ -32,12 +40,13 @@ document.getElementById('view-creds').addEventListener('click', () => {
 
 document.getElementById('saveCredentials').addEventListener('click', () => {
   const clientId = document.getElementById('clientIdInput').value.trim();
-  if (!clientId) {
-    alert('Client ID is required.');
+  const clientSecret = document.getElementById('clientSecretInput').value.trim();
+  if (!clientId || !clientSecret) {
+    alert('Client ID and Client Secret are required.');
     return;
   }
-  saveCredentials(clientId);
-  ({ clientId: CLIENT_ID } = getCredentials());
+  saveCredentials(clientId, clientSecret);
+  ({ clientId: CLIENT_ID, clientSecret: CLIENT_SECRET } = getCredentials());
   credModal.hide();
   document.getElementById('view-creds').classList.remove('d-none');
   if (gisInited) {
@@ -45,8 +54,8 @@ document.getElementById('saveCredentials').addEventListener('click', () => {
   }
 });
 
-let { clientId: CLIENT_ID } = getCredentials();
-if (CLIENT_ID) {
+let { clientId: CLIENT_ID, clientSecret: CLIENT_SECRET } = getCredentials();
+if (CLIENT_ID && CLIENT_SECRET) {
   document.getElementById('view-creds').classList.remove('d-none');
   if (gisInited) {
     initTokenClient();
@@ -88,7 +97,7 @@ async function initializeGapiClient() {
 
 window.gisLoaded = function() {
   gisInited = true;
-  if (CLIENT_ID) {
+  if (CLIENT_ID && CLIENT_SECRET) {
     initTokenClient();
   }
 };
@@ -96,6 +105,7 @@ window.gisLoaded = function() {
 function initTokenClient() {
   tokenClient = google.accounts.oauth2.initTokenClient({
     client_id: CLIENT_ID,
+    client_secret: CLIENT_SECRET,
     scope: 'https://www.googleapis.com/auth/calendar.readonly',
     callback: () => {}
   });

--- a/index.html
+++ b/index.html
@@ -35,6 +35,10 @@
             <label for="clientIdInput" class="form-label">Client ID</label>
             <input type="text" class="form-control" id="clientIdInput">
           </div>
+          <div class="mb-3">
+            <label for="clientSecretInput" class="form-label">Client Secret</label>
+            <input type="text" class="form-control" id="clientSecretInput">
+          </div>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-primary" id="saveCredentials">Save</button>


### PR DESCRIPTION
## Summary
- Store client secret with client ID and pass it during token client initialization.
- Extend credentials modal to capture client secret.
- Document client secret usage in setup instructions.

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd342ec74c8323a222902b7ca3c7e0