### PR TITLE
feat: add stakeholder configuration UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ Gartner analysts, or direct reports.
 3. When you first launch the app you will be prompted in the browser to enter
    your OAuth client ID and client secret. The app stores these in
    `sessionStorage` so you only need to provide them once per session.
-4. Optionally edit `config.json` to specify emails for key groups:
+4. Click **Configure Stakeholders** in the app to set email addresses for the
+   executive team, Gartner analysts, and direct reports. These values are saved
+   in `localStorage` and override the defaults in `config.json`.
+5. Optionally edit `config.json` to specify default emails for key groups:
 
 ```json
 {

--- a/app.js
+++ b/app.js
@@ -10,8 +10,32 @@ function getCredentials() {
   };
 }
 
+function saveStakeholderConfig(config) {
+  localStorage.setItem('STAKEHOLDERS_CONFIG', JSON.stringify(config));
+}
+
+function getStakeholderConfig() {
+  const raw = localStorage.getItem('STAKEHOLDERS_CONFIG');
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch (e) {
+    return null;
+  }
+}
+
+function parseEmails(text) {
+  return text
+    .split(/[\s,]+/)
+    .map(e => e.trim().toLowerCase())
+    .filter(e => e);
+}
+
 const credModal = new bootstrap.Modal(
   document.getElementById('credentialsModal')
+);
+const stakeholderModal = new bootstrap.Modal(
+  document.getElementById('stakeholdersModal')
 );
 
 document.getElementById('refresh').addEventListener('click', refresh);
@@ -23,6 +47,26 @@ document.getElementById('config').addEventListener('click', () => {
   document.getElementById('clientSecretInput').removeAttribute('readonly');
   document.getElementById('saveCredentials').classList.remove('d-none');
   credModal.show();
+});
+
+document.getElementById('configStakeholders').addEventListener('click', async () => {
+  const cfg = await fetchConfig();
+  document.getElementById('execTeamInput').value = (cfg.exec_team || []).join(', ');
+  document.getElementById('gartnerInput').value = (cfg.gartner_analysts || []).join(', ');
+  document.getElementById('directReportsInput').value = (cfg.direct_reports || []).join(', ');
+  stakeholderModal.show();
+});
+
+document.getElementById('saveStakeholders').addEventListener('click', () => {
+  const config = {
+    exec_team: parseEmails(document.getElementById('execTeamInput').value),
+    gartner_analysts: parseEmails(document.getElementById('gartnerInput').value),
+    direct_reports: parseEmails(
+      document.getElementById('directReportsInput').value
+    )
+  };
+  saveStakeholderConfig(config);
+  stakeholderModal.hide();
 });
 
 document.getElementById('view-creds').addEventListener('click', () => {
@@ -165,8 +209,12 @@ async function refresh() {
 }
 
 async function fetchConfig() {
+  const stored = getStakeholderConfig();
+  if (stored) return stored;
   const res = await fetch('config.json');
-  return res.json();
+  const cfg = await res.json();
+  saveStakeholderConfig(cfg);
+  return cfg;
 }
 
 async function fetchEvents() {

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     <div class="mb-3 text-center">
       <button id="config" class="btn btn-secondary me-2">Configure Credentials</button>
       <button id="view-creds" class="btn btn-outline-secondary btn-sm me-2 d-none" title="Show Credentials">🔑</button>
+      <button id="configStakeholders" class="btn btn-secondary me-2">Configure Stakeholders</button>
       <button id="refresh" class="btn btn-primary">Refresh Stats</button>
     </div>
     <pre id="output" class="bg-white p-3 border rounded"></pre>
@@ -42,6 +43,34 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-primary" id="saveCredentials">Save</button>
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="modal" tabindex="-1" id="stakeholdersModal">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Key Stakeholders</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label for="execTeamInput" class="form-label">Exec Team (comma separated)</label>
+            <textarea class="form-control" id="execTeamInput" rows="3"></textarea>
+          </div>
+          <div class="mb-3">
+            <label for="gartnerInput" class="form-label">Gartner Analysts (comma separated)</label>
+            <textarea class="form-control" id="gartnerInput" rows="3"></textarea>
+          </div>
+          <div class="mb-3">
+            <label for="directReportsInput" class="form-label">Direct Reports (comma separated)</label>
+            <textarea class="form-control" id="directReportsInput" rows="3"></textarea>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-primary" id="saveStakeholders">Save</button>
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- allow configuring stakeholder email groups via new modal
- save stakeholder config in localStorage and load when computing stats
- document stakeholder configuration in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd35f665fc8329a7e721ac31f66176