### PR TITLE
Show running event count while fetching calendar data

### DIFF
--- a/app.js
+++ b/app.js
@@ -329,7 +329,7 @@ async function fetchConfig() {
   }
 }
 
-async function fetchEvents() {
+async function fetchEvents(onProgress) {
   const now = new Date();
   const timeMin = new Date(
     now.getTime() - 90 * 24 * 60 * 60 * 1000
@@ -346,6 +346,7 @@ async function fetchEvents() {
       pageToken
     });
     events = events.concat(res.result.items || []);
+    onProgress?.(events.length);
     pageToken = res.result.nextPageToken;
   } while (pageToken);
   return events;
@@ -465,7 +466,9 @@ async function getStats(onProgress) {
   onProgress?.('Loading configuration...');
   const config = await fetchConfig();
   onProgress?.('Fetching calendar events...');
-  const events = await fetchEvents();
+  const events = await fetchEvents(count => {
+    onProgress?.(`Fetching calendar events... (${count})`);
+  });
   onProgress?.('Computing statistics...');
   return computeStats(events, config);
 }


### PR DESCRIPTION
## Summary
- report running count of events while retrieving calendar pages
- propagate progress updates from `getStats` to the UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd3a5367308329a4aeee05312114a9