### PR TITLE
Remove restrictive meta policies causing browser warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,6 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <meta http-equiv="Permissions-Policy" content="unload=*">
-  <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin-allow-popups">
   <title>Calendar Analytics</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <style>


### PR DESCRIPTION
## Summary
- Remove `Permissions-Policy` and `Cross-Origin-Opener-Policy` meta tags from `index.html`
- Allow Google APIs scripts to operate without permissions and COOP violations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd3b6c18f88329aa90715b7006b9e4