### PR TITLE
Progressively update charts during data fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,6 @@ Gartner analysts, or direct reports.
 The application uses your existing Google account session and runs entirely in
 the browser; no server-side component is required.
 
+While calendar data is being fetched, the charts update progressively so you can
+see statistics as soon as they become available.
+


### PR DESCRIPTION
## Summary
- Render charts incrementally while Google Calendar events are being fetched
- Update README to note progressive chart updates

## Testing
- `npm test`
- `node --check app.js && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_68bd3bbff91083299b6a54ced2828c96