### PR TITLE
Add Gartner meetings table extracted from event descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
       <div class="col-md-6"><canvas id="timeChart"></canvas></div>
     </div>
     <div id="individualCharts" class="mb-4"></div>
+    <div id="gartnerTable" class="mb-4"></div>
     <pre id="output" class="bg-white p-3 border rounded"></pre>
   </div>
   <div class="modal" tabindex="-1" id="credentialsModal">


### PR DESCRIPTION
## Summary
- Parse Gartner expert names and reference numbers from event descriptions
- Collect Gartner and non-Gartner attendees and expose detailed meeting data
- Render a new table in the UI listing each Gartner meeting with date, time, reference, and attendees

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be81b19af48329a23142e4a7181ed9